### PR TITLE
Ensure mssql server module configures administrators

### DIFF
--- a/platform/infra/Azure/modules/mssql-server/README.md
+++ b/platform/infra/Azure/modules/mssql-server/README.md
@@ -1,0 +1,14 @@
+# mssql-server module
+
+Provision an Azure SQL Server instance that supports either SQL authentication or Azure AD administration.
+
+## Inputs
+
+- `name` (`string`, required) – Name of the SQL server resource.
+- `location` (`string`, required) – Azure region where the server is deployed.
+- `resource_group_name` (`string`, required) – Resource group that will contain the server.
+- `admin_login` (`string`, optional) – SQL administrator login to provision. Must be provided together with `admin_password` when using SQL authentication.
+- `admin_password` (`string`, optional) – SQL administrator password to provision. Must be provided together with `admin_login` when using SQL authentication.
+- `azuread_administrator` (`object`, optional) – Azure AD administrator settings for the server. When supplied, it must include `login_username` and `object_id`, and it can optionally include `tenant_id`.
+
+Either the SQL administrator credentials (`admin_login` and `admin_password`) or an `azuread_administrator` block must be provided to satisfy Azure API requirements.

--- a/platform/infra/Azure/modules/mssql-server/main.tf
+++ b/platform/infra/Azure/modules/mssql-server/main.tf
@@ -1,8 +1,38 @@
+locals {
+  admin_login_provided       = var.admin_login != null && trimspace(var.admin_login) != ""
+  admin_password_provided    = var.admin_password != null && var.admin_password != ""
+  admin_credentials_provided = local.admin_login_provided && local.admin_password_provided
+  azuread_admin_provided     = var.azuread_administrator != null
+}
+
 resource "azurerm_mssql_server" "this" {
-  name                         = var.name
-  resource_group_name          = var.resource_group_name
-  location                     = var.location
-  version                      = "12.0"
-  # administrator_login          = var.admin_login
-  # administrator_login_password = var.admin_password
+  name                = var.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  version             = "12.0"
+
+  administrator_login          = local.admin_credentials_provided ? var.admin_login : null
+  administrator_login_password = local.admin_credentials_provided ? var.admin_password : null
+
+  dynamic "azuread_administrator" {
+    for_each = local.azuread_admin_provided ? [var.azuread_administrator] : []
+
+    content {
+      login_username = azuread_administrator.value.login_username
+      object_id      = azuread_administrator.value.object_id
+      tenant_id      = try(azuread_administrator.value.tenant_id, null)
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = local.admin_login_provided == local.admin_password_provided
+      error_message = "Both admin_login and admin_password must be provided together."
+    }
+
+    precondition {
+      condition     = local.admin_credentials_provided || local.azuread_admin_provided
+      error_message = "You must provide either admin_login/admin_password or an azuread_administrator configuration."
+    }
+  }
 }

--- a/platform/infra/Azure/modules/mssql-server/variables.tf
+++ b/platform/infra/Azure/modules/mssql-server/variables.tf
@@ -1,5 +1,45 @@
-variable "name" {}
-variable "location" {}
-variable "resource_group_name" {}
-variable "sku" { default = "Standard" }
-variable "public_ip_id" {}
+variable "name" {
+  description = "Name of the SQL server."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region where the server will be deployed."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group that will contain the server."
+  type        = string
+}
+
+variable "admin_login" {
+  description = "Administrator login for the SQL server. Provide together with admin_password or leave null when configuring Azure AD administration."
+  type        = string
+  default     = null
+}
+
+variable "admin_password" {
+  description = "Administrator password for the SQL server. Provide together with admin_login or leave null when configuring Azure AD administration."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "azuread_administrator" {
+  description = "Optional Azure AD administrator configuration for the SQL server."
+  type = object({
+    login_username = string
+    object_id      = string
+    tenant_id      = optional(string)
+  })
+  default = null
+
+  validation {
+    condition = var.azuread_administrator == null || (
+      trimspace(var.azuread_administrator.login_username) != "" &&
+      trimspace(var.azuread_administrator.object_id) != ""
+    )
+    error_message = "When specified, azuread_administrator.login_username and azuread_administrator.object_id must be non-empty."
+  }
+}


### PR DESCRIPTION
## Summary
- require the SQL server module to provide either SQL credentials or an Azure AD administrator configuration
- declare the necessary administrator input variables and document them in the module README

## Testing
- terraform -chdir=platform/infra/Azure/modules/mssql-server init -backend=false *(fails: terraform command not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caf9f9da548326a233b07dc2531a08