### PR TITLE
Restore Linux VM required inputs

### DIFF
--- a/platform/infra/Azure/modules/linux-virtual-machine/main.tf
+++ b/platform/infra/Azure/modules/linux-virtual-machine/main.tf
@@ -1,9 +1,18 @@
+locals {
+  admin_password_trimmed  = trimspace(coalesce(var.admin_password, ""))
+  admin_password_provided = local.admin_password_trimmed != ""
+  ssh_key_trimmed         = trimspace(coalesce(var.ssh_key, ""))
+  ssh_key_provided        = local.ssh_key_trimmed != ""
+}
+
 resource "azurerm_linux_virtual_machine" "this" {
   name                = var.name
   location            = var.location
   resource_group_name = var.resource_group_name
-  # size                = var.size
-  # admin_username      = var.admin_username
+  size                = var.size
+  admin_username      = var.admin_username
+  admin_password      = local.admin_password_provided ? local.admin_password_trimmed : null
+  disable_password_authentication = !local.admin_password_provided
 
   network_interface_ids = [var.nic_id]
 
@@ -12,15 +21,25 @@ resource "azurerm_linux_virtual_machine" "this" {
     storage_account_type = "Standard_LRS"
   }
 
-  # source_image_reference {
-  #   publisher = var.image_publisher
-  #   offer     = var.image_offer
-  #   sku       = var.image_sku
-  #   version   = "latest"
-  # }
-  #
-  # admin_ssh_key {
-  #   username   = var.admin_username
-  #   public_key = var.ssh_key
-  # }
+  source_image_reference {
+    publisher = var.image_publisher
+    offer     = var.image_offer
+    sku       = var.image_sku
+    version   = var.image_version
+  }
+
+  dynamic "admin_ssh_key" {
+    for_each = local.ssh_key_provided ? [local.ssh_key_trimmed] : []
+    content {
+      username   = var.admin_username
+      public_key = admin_ssh_key.value
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = local.ssh_key_provided || local.admin_password_provided
+      error_message = "Either ssh_key or admin_password must be provided."
+    }
+  }
 }

--- a/platform/infra/Azure/modules/linux-virtual-machine/variables.tf
+++ b/platform/infra/Azure/modules/linux-virtual-machine/variables.tf
@@ -13,19 +13,61 @@ variable "resource_group_name" {
   type        = string
 }
 
-variable "sku" {
-  description = "SKU/size of the virtual machine."
+variable "size" {
+  description = "Size of the virtual machine (for example, Standard_B2s)."
   type        = string
-  default     = "Standard"
+}
+
+variable "admin_username" {
+  description = "Administrator username for the virtual machine."
+  type        = string
+}
+
+variable "admin_password" {
+  description = "Optional administrator password for the virtual machine. If omitted, SSH key authentication must be provided."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "ssh_key" {
+  description = "Optional SSH public key used for administrator authentication."
+  type        = string
+  default     = null
+}
+
+variable "image_publisher" {
+  description = "Publisher of the operating system image."
+  type        = string
+}
+
+variable "image_offer" {
+  description = "Offer of the operating system image."
+  type        = string
+}
+
+variable "image_sku" {
+  description = "SKU of the operating system image."
+  type        = string
+}
+
+variable "image_version" {
+  description = "Version of the operating system image."
+  type        = string
+  default     = "latest"
 }
 
 variable "nic_id" {
   description = "Resource ID of the primary network interface to attach to the VM."
   type        = string
-  default     = ""
 
   validation {
-    condition     = var.nic_id == "" || can(regex("^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/networkInterfaces/[^/]+$", trimspace(var.nic_id)))
-    error_message = "nic_id must be empty or a valid Azure resource ID for a network interface."
+    condition     = var.nic_id == null || trimspace(var.nic_id) != ""
+    error_message = "nic_id must be provided."
+  }
+
+  validation {
+    condition     = var.nic_id == null || can(regex("^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/networkInterfaces/[^/]+$", trimspace(var.nic_id)))
+    error_message = "nic_id must be a valid Azure resource ID for a network interface."
   }
 }


### PR DESCRIPTION
## Summary
- restore required arguments on the linux VM resource including size, credentials, and image configuration
- expand the module inputs so callers can provide admin credentials, SSH key, and OS image information
- enforce a precondition to ensure that either a password or SSH key is supplied before provisioning

## Testing
- terraform validate *(fails: terraform binary unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caf9f589088326a24531232956cfde