### PR TITLE
Remove redundant DNS arguments from stage network module

### DIFF
--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -43,8 +43,6 @@ module "network" {
   dns_servers         = var.vnet_dns_servers
   subnets             = var.subnets
   tags                = var.tags
-  a_records           = var.dns_a_records
-  cname_records       = var.dns_cname_records
 }
 
 module "app_service" {


### PR DESCRIPTION
## Summary
- remove DNS record arguments from the stage network module call so records remain managed by the dns_zone module

## Testing
- terraform validate (fails: terraform binary is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68caf9f327d8832698e6a7c910943f2b