### PR TITLE
Add Azure AD provider configuration for envs

### DIFF
--- a/platform/infra/envs/dev/providers.tf
+++ b/platform/infra/envs/dev/providers.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "4.33.0"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
   }
 }
 
@@ -18,4 +22,8 @@ provider "azurerm" {
 
   subscription_id = local.provider_subscription_id
   tenant_id       = local.provider_tenant_id
+}
+
+provider "azuread" {
+  tenant_id = local.provider_tenant_id
 }

--- a/platform/infra/envs/prod/providers.tf
+++ b/platform/infra/envs/prod/providers.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "4.33.0"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
   }
 }
 
@@ -17,4 +21,8 @@ provider "azurerm" {
 
   subscription_id = local.provider_subscription_id
   tenant_id       = local.provider_tenant_id
+}
+
+provider "azuread" {
+  tenant_id = local.provider_tenant_id
 }

--- a/platform/infra/envs/stage/providers.tf
+++ b/platform/infra/envs/stage/providers.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "4.33.0"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
   }
 }
 
@@ -17,4 +21,8 @@ provider "azurerm" {
 
   subscription_id = local.provider_subscription_id
   tenant_id       = local.provider_tenant_id
+}
+
+provider "azuread" {
+  tenant_id = local.provider_tenant_id
 }


### PR DESCRIPTION
## Summary
- add the Azure AD provider requirement and configuration to the dev environment so the aad-app module can be used
- mirror the Azure AD provider settings in the stage and prod environments for consistency

## Testing
- `terraform init -upgrade` *(fails: terraform binary is unavailable in the execution environment)*
- `terraform validate` *(not run: terraform binary is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caf9f1dfb88326aa96139a49a977b9