### PR TITLE
Ensure arbitration app pipeline targets Windows App Service

### DIFF
--- a/.ado/pipelines/arbitration-app.yml
+++ b/.ado/pipelines/arbitration-app.yml
@@ -3,6 +3,29 @@
 # Environment approvals for stage/prod should be configured on the
 # corresponding Azure DevOps environments (arbitration-stage, arbitration-prod).
 
+parameters:
+- name: devAppType
+  displayName: App Service type (dev)
+  type: string
+  default: webApp
+  values:
+  - webApp
+  - webAppLinux
+- name: stageAppType
+  displayName: App Service type (stage)
+  type: string
+  default: webApp
+  values:
+  - webApp
+  - webAppLinux
+- name: prodAppType
+  displayName: App Service type (prod)
+  type: string
+  default: webApp
+  values:
+  - webApp
+  - webAppLinux
+
 trigger:
   branches: { include: [ main ] }
   paths: { include: [ 'Arbitration/**', '.ado/pipelines/arbitration-app.yml' ] }
@@ -36,6 +59,7 @@ stages:
       environmentName: arbitration-dev
       displayNameSuffix: dev
       azureSubscription: sc-azure-oidc-dev
+      appType: ${{ parameters.devAppType }}
 
 - stage: deploy_stage
   displayName: Deploy to stage
@@ -50,6 +74,7 @@ stages:
       environmentName: arbitration-stage
       displayNameSuffix: stage
       azureSubscription: sc-azure-oidc-stage
+      appType: ${{ parameters.stageAppType }}
 
 - stage: deploy_prod
   displayName: Deploy to prod
@@ -64,3 +89,4 @@ stages:
       environmentName: arbitration-prod
       displayNameSuffix: prod
       azureSubscription: sc-azure-oidc-prod
+      appType: ${{ parameters.prodAppType }}

--- a/.ado/templates/arbitration-deploy.yml
+++ b/.ado/templates/arbitration-deploy.yml
@@ -10,7 +10,7 @@ parameters:
   type: string
 - name: appType
   type: string
-  default: webAppLinux
+  default: webApp
 jobs:
 - deployment: ${{ parameters.jobName }}
   displayName: Deploy to ${{ parameters.displayNameSuffix }}


### PR DESCRIPTION
## Summary
- default the arbitration deployment template to the Windows Web App runtime
- expose per-environment app type parameters so stages can opt into Linux plans if needed

## Testing
- not run (pipeline execution requires Azure DevOps access)


------
https://chatgpt.com/codex/tasks/task_e_68caff11e5708326b2c197ba60c88276