### PR TITLE
Restore arbitration tests project and update pipeline path

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ stages:
       displayName: Run Arbitration tests
       inputs:
         command: 'test'
-        projects: 'tests/TestArbitApi/Tests.csproj'
+        projects: './tests/TestArbitApi/Tests.csproj'
         arguments: '--configuration Release --no-build --no-restore'
   - template: .ado/templates/tf-validate.yml
     parameters:

--- a/tests/TestArbitApi/Tests.csproj
+++ b/tests/TestArbitApi/Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Arbitration\MPArbitration\MPArbitration.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/TestArbitApi/UnitTest_NegotiationNoticeDeadline.cs
+++ b/tests/TestArbitApi/UnitTest_NegotiationNoticeDeadline.cs
@@ -1,0 +1,70 @@
+using MPArbitration.Model;
+
+namespace TestArbitApi
+{
+    public class UnitTest_NegotiationNoticeDeadline
+    {
+        string JSONData = "{\"NegotiationNoticeDeadline\":\"2022-06-07T06:00:00+00:00\",\"DateNegotiationSent\":\"2022-04-12T06:00:00+00:00\",\"NegotiationDeadline\":\"2022-05-23T06:00:00+00:00\",\"ArbitrationFilingStartDate\":\"2022-05-24T06:00:00+00:00\",\"ArbitrationFilingDeadline\":\"2022-05-27T06:00:00+00:00\",\"SubmittedToAuthority\":null,\"PayorAcceptanceDeadline\":null,\"ArbitratorSelectionDeadline\":null,\"ArbitratorAssignedOn\":null,\"NoConflictConfirmationDeadline\":null,\"ArbitrationBriefDueOn\":null,\"ArbitrationFeeDeadline\":null,\"AuthorityResolutionDeadline\":null,\"DateDecisionWasMade\":null,\"PaymentDeadlineIfWon\":null,\"ArbitrationFeeRefundDeadline\":null}";
+        [Fact]
+        public void TestNegotiationNoticeDeadline_WithDateInCorrectFormatInJsonData()
+        {
+            var arb = new ArbitrationCase();
+            arb.NSATracking = JSONData;
+            Assert.Equal("2022-06-07", arb.NegotiationNoticeDeadline!.Value.ToString("yyyy-MM-dd"));
+        }
+        [Fact]
+        public void TestNegotiationNoticeDeadline_EmptyJSONShouldPickEOBDate()
+        {
+            var arb = new ArbitrationCase() { EOBDate = DateTime.Parse("2024-07-01") };
+            arb.NSATracking = "";
+            Assert.Equal(arb.EOBDate.Value.AddDays(29).ToString("yyyy-MM-dd"), arb.NegotiationNoticeDeadline!.Value.ToString("yyyy-MM-dd"));
+        }
+        [Fact]
+        public void TestNegotiationNoticeDeadline_BadFormatStringDateFormatException()
+        {
+            string JSONDataBad = "{\"NegotiationNoticeDeadline\":\"202-06-07T06:00:00+00:00\",}";
+            var arb = new ArbitrationCase();
+            Assert.Throws<FormatException>(() => arb.NSATracking = JSONDataBad);
+        }
+        [Fact]
+        public void TestNegotiationNoticeDeadline_NullAsValue()
+        {
+            string JSONDataBad = "{\"NegotiationNoticeDeadline\":null,}";
+            var arb = new ArbitrationCase();
+            arb.NSATracking = JSONDataBad;
+            Assert.Null(arb.NegotiationNoticeDeadline);
+        }
+        [Fact]
+        public void TestNegotiationNoticeDeadline_Empty()
+        {
+            string JSONDataBad = "{\"NegotiationNoticeDeadline\":\"\",}";
+            var arb = new ArbitrationCase();
+            arb.NSATracking = JSONDataBad;
+            Assert.Null(arb.NegotiationNoticeDeadline);
+        }
+        [Fact]
+        public void TestNegotiationNoticeDeadline_NoValue()
+        {
+            string JSONDataBad = "{}";
+            var arb = new ArbitrationCase();
+            arb.NSATracking = JSONDataBad;
+            Assert.Null(arb.NegotiationNoticeDeadline);
+        }
+        [Fact]
+        public void TestNegotiationNoticeDeadline_NulData()
+        {
+            string JSONDataBad = "{}";
+            var arb = new ArbitrationCase();
+            arb.NSATracking = null;
+            Assert.Null(arb.NegotiationNoticeDeadline);
+        }
+        [Fact]
+        public void TestNegotiationNoticeDeadline_EmptyStringAsData()
+        {
+            string JSONDataBad = "{}";
+            var arb = new ArbitrationCase();
+            arb.NSATracking = string.Empty;
+            Assert.Null(arb.NegotiationNoticeDeadline);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- restore the missing arbitration API test project under tests/TestArbitApi
- reference the arbitration solution from the restored tests project and point the pipeline test step at the correct path

## Testing
- dotnet test Arbitration/MPArbitration.sln --configuration Release *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caff0a8514832689350fe3c884714f