### PR TITLE
Inject SQL admin secrets via pipeline

### DIFF
--- a/.ado/templates/tf-plan.yml
+++ b/.ado/templates/tf-plan.yml
@@ -33,6 +33,12 @@ parameters:
   - name: akvSecretSqlAdminPasswordName
     type: string
     default: 'sql-admin-password'
+  - name: pipelineSqlAdminLogin
+    type: string
+    default: ''
+  - name: pipelineSqlAdminPassword
+    type: string
+    default: ''
 
 jobs:
 - job: plan_${{ parameters.envName }}
@@ -82,18 +88,40 @@ jobs:
             fi
           fi
 
-          # Pull secrets (avoid echoing values)
-          set +x
-          SQL_ADMIN_LOGIN="$(az keyvault secret show --vault-name "$KV_NAME" --name "$SECRET_LOGIN" --query value -o tsv || true)"
-          SQL_ADMIN_PASSWORD="$(az keyvault secret show --vault-name "$KV_NAME" --name "$SECRET_PASS" --query value -o tsv || true)"
-          set -x
+        fi
 
-          if [[ -n "$SQL_ADMIN_LOGIN" && -n "$SQL_ADMIN_PASSWORD" ]]; then
-            AKV_VAR_FLAGS="-var \"sql_admin_login=${SQL_ADMIN_LOGIN}\" -var \"sql_admin_password=${SQL_ADMIN_PASSWORD}\""
-          else
-            echo "NOTE: SQL secrets missing or empty in Key Vault '${KV_NAME}'. Skipping SQL vars."
+        # Pull secrets from Key Vault or pipeline variables without echoing sensitive data
+        set +x
+        SQL_ADMIN_LOGIN=""
+        SQL_ADMIN_PASSWORD=""
+        PIPELINE_SQL_ADMIN_LOGIN="${PIPELINE_SQL_ADMIN_LOGIN:-}"
+        PIPELINE_SQL_ADMIN_PASSWORD="${PIPELINE_SQL_ADMIN_PASSWORD:-}"
+
+        if [[ "$USE_AKV" == "true" && -n "$KV_NAME" ]]; then
+          KV_SQL_ADMIN_LOGIN="$(az keyvault secret show --vault-name "$KV_NAME" --name "$SECRET_LOGIN" --query value -o tsv || true)"
+          KV_SQL_ADMIN_PASSWORD="$(az keyvault secret show --vault-name "$KV_NAME" --name "$SECRET_PASS" --query value -o tsv || true)"
+
+          if [[ -n "$KV_SQL_ADMIN_LOGIN" ]]; then
+            SQL_ADMIN_LOGIN="$KV_SQL_ADMIN_LOGIN"
+          fi
+          if [[ -n "$KV_SQL_ADMIN_PASSWORD" ]]; then
+            SQL_ADMIN_PASSWORD="$KV_SQL_ADMIN_PASSWORD"
           fi
         fi
+
+        if [[ -z "$SQL_ADMIN_LOGIN" && -n "$PIPELINE_SQL_ADMIN_LOGIN" ]]; then
+          SQL_ADMIN_LOGIN="$PIPELINE_SQL_ADMIN_LOGIN"
+        fi
+        if [[ -z "$SQL_ADMIN_PASSWORD" && -n "$PIPELINE_SQL_ADMIN_PASSWORD" ]]; then
+          SQL_ADMIN_PASSWORD="$PIPELINE_SQL_ADMIN_PASSWORD"
+        fi
+
+        if [[ -n "$SQL_ADMIN_LOGIN" && -n "$SQL_ADMIN_PASSWORD" ]]; then
+          AKV_VAR_FLAGS="-var \"sql_admin_login=${SQL_ADMIN_LOGIN}\" -var \"sql_admin_password=${SQL_ADMIN_PASSWORD}\""
+        else
+          echo "NOTE: SQL admin credentials not supplied via Key Vault or pipeline variables for '${{ parameters.envName }}'. Skipping SQL vars."
+        fi
+        set -x
 
         cd platform/infra/envs/${{ parameters.envName }}
         if [[ -n "${AZ_SUBSCRIPTION_ID:-}" ]]; then
@@ -105,6 +133,9 @@ jobs:
 
         terraform init -reconfigure -backend-config=backend.tfvars -lock-timeout='${{ parameters.lockTimeout }}'
         terraform plan -input=false -var-file=terraform.tfvars ${{ parameters.extraVarFlags }} ${SUB_TENANT_VAR_FLAGS} ${AKV_VAR_FLAGS} -out "$BUILD_SOURCESDIRECTORY/tfplan-${{ parameters.envName }}.tfplan"
+    env:
+      PIPELINE_SQL_ADMIN_LOGIN: ${{ parameters.pipelineSqlAdminLogin }}
+      PIPELINE_SQL_ADMIN_PASSWORD: ${{ parameters.pipelineSqlAdminPassword }}
   - task: PublishPipelineArtifact@1
     inputs:
       targetPath: '$(Build.SourcesDirectory)/tfplan-${{ parameters.envName }}.tfplan'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,6 +80,8 @@ stages:
       akvEnableDynamicIp: '$(AKV_ENABLE_DYNAMIC_IP_DEV)'
       akvSecretSqlAdminLoginName: '$(AKV_SECRET_SQL_ADMIN_LOGIN_NAME)'
       akvSecretSqlAdminPasswordName: '$(AKV_SECRET_SQL_ADMIN_PASSWORD_NAME)'
+      pipelineSqlAdminLogin: '$(SQL_ADMIN_LOGIN_DEV)'
+      pipelineSqlAdminPassword: '$(SQL_ADMIN_PASSWORD_DEV)'
   - template: .ado/templates/tf-plan.yml
     parameters:
       envName: qa
@@ -93,6 +95,8 @@ stages:
       akvEnableDynamicIp: '$(AKV_ENABLE_DYNAMIC_IP_QA)'
       akvSecretSqlAdminLoginName: '$(AKV_SECRET_SQL_ADMIN_LOGIN_NAME)'
       akvSecretSqlAdminPasswordName: '$(AKV_SECRET_SQL_ADMIN_PASSWORD_NAME)'
+      pipelineSqlAdminLogin: '$(SQL_ADMIN_LOGIN_QA)'
+      pipelineSqlAdminPassword: '$(SQL_ADMIN_PASSWORD_QA)'
   - template: .ado/templates/tf-plan.yml
     parameters:
       envName: stage
@@ -106,6 +110,8 @@ stages:
       akvEnableDynamicIp: '$(AKV_ENABLE_DYNAMIC_IP_STAGE)'
       akvSecretSqlAdminLoginName: '$(AKV_SECRET_SQL_ADMIN_LOGIN_NAME)'
       akvSecretSqlAdminPasswordName: '$(AKV_SECRET_SQL_ADMIN_PASSWORD_NAME)'
+      pipelineSqlAdminLogin: '$(SQL_ADMIN_LOGIN_STAGE)'
+      pipelineSqlAdminPassword: '$(SQL_ADMIN_PASSWORD_STAGE)'
   - template: .ado/templates/tf-plan.yml
     parameters:
       envName: prod
@@ -119,6 +125,8 @@ stages:
       akvEnableDynamicIp: '$(AKV_ENABLE_DYNAMIC_IP_PROD)'
       akvSecretSqlAdminLoginName: '$(AKV_SECRET_SQL_ADMIN_LOGIN_NAME)'
       akvSecretSqlAdminPasswordName: '$(AKV_SECRET_SQL_ADMIN_PASSWORD_NAME)'
+      pipelineSqlAdminLogin: '$(SQL_ADMIN_LOGIN_PROD)'
+      pipelineSqlAdminPassword: '$(SQL_ADMIN_PASSWORD_PROD)'
 
 - stage: Apply_Dev
   displayName: Terraform Apply (dev)

--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -20,6 +20,8 @@ locals {
   storage_data_name                     = lower(replace("st${var.project_name}${var.env_name}data", "-", ""))
   sql_server_name                       = "sql-${var.project_name}-${var.env_name}"
   aad_app_display                       = "aad-${var.project_name}-${var.env_name}"
+  sql_admin_login_effective             = trimspace(coalesce(var.sql_admin_login, ""))
+  sql_admin_password_effective          = coalesce(var.sql_admin_password, "")
 }
 
 module "resource_group" {
@@ -139,7 +141,7 @@ module "app_gateway" {
 }
 
 module "sql" {
-  count                         = var.enable_sql && var.sql_admin_login != "" && var.sql_admin_password != "" ? 1 : 0
+  count                         = var.enable_sql && local.sql_admin_login_effective != "" && local.sql_admin_password_effective != "" ? 1 : 0
   source                        = "../../Azure/modules/sql-serverless"
   server_name                   = local.sql_server_name
   database_name                 = var.sql_database_name

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -100,8 +100,8 @@ sql_max_size_gb           = 75
 sql_min_capacity          = 0.5
 sql_max_capacity          = 4
 sql_public_network_access = true
-sql_admin_login           = ""
-sql_admin_password        = ""
+
+# SQL administrator credentials are supplied at runtime via the pipeline / Key Vault.
 
 sql_firewall_rules = [
   {

--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -347,13 +347,14 @@ variable "sql_firewall_rules" {
 variable "sql_admin_login" {
   description = "Administrator login for the SQL server."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "sql_admin_password" {
   description = "Administrator password for the SQL server. Provide this securely via environment variable or Key Vault."
   type        = string
   sensitive   = true
+  default     = null
 }
 
 # -------------------------

--- a/platform/infra/envs/prod/main.tf
+++ b/platform/infra/envs/prod/main.tf
@@ -22,6 +22,8 @@ locals {
 
   sql_server_name   = "sql-${var.project_name}-${var.env_name}"
   sql_database_name = var.sql_database_name != "" ? var.sql_database_name : "${var.project_name}-${var.env_name}"
+  sql_admin_login_effective    = trimspace(coalesce(var.sql_admin_login, ""))
+  sql_admin_password_effective = coalesce(var.sql_admin_password, "")
 }
 
 # -------------------------
@@ -82,7 +84,7 @@ module "app_gateway" {
 }
 
 module "sql" {
-  count                         = var.enable_sql ? 1 : 0
+  count                         = var.enable_sql && local.sql_admin_login_effective != "" && local.sql_admin_password_effective != "" ? 1 : 0
   source                        = "../../Azure/modules/sql-serverless"
   server_name                   = local.sql_server_name
   database_name                 = local.sql_database_name

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -9,6 +9,11 @@ tags = {
 }
 
 # -------------------------
+# Feature flags
+# -------------------------
+enable_sql = true
+
+# -------------------------
 # Networking
 # -------------------------
 vnet_address_space = ["10.30.0.0/16"]
@@ -89,8 +94,10 @@ sql_min_capacity         = 2
 sql_max_capacity         = 8
 sql_public_network_access = true
 
-sql_admin_login    = "sqladminprod"
-sql_admin_password = "P@ssw0rd123!Prod"
+sql_admin_login    = null
+sql_admin_password = null
+
+# SQL administrator credentials are supplied securely at deploy time (Key Vault or pipeline variables).
 
 # Firewall rules
 sql_firewall_rules = [

--- a/platform/infra/envs/prod/variables.tf
+++ b/platform/infra/envs/prod/variables.tf
@@ -333,12 +333,14 @@ variable "sql_firewall_rules" {
 variable "sql_admin_login" {
   description = "Administrator login for the SQL server."
   type        = string
+  default     = null
 }
 
 variable "sql_admin_password" {
   description = "Administrator password for the SQL server."
   type        = string
   sensitive   = true
+  default     = null
 }
 
 # -------------------------

--- a/platform/infra/envs/stage/main.tf
+++ b/platform/infra/envs/stage/main.tf
@@ -22,6 +22,8 @@ locals {
 
   sql_server_name   = "sql-${var.project_name}-${var.env_name}"
   sql_database_name = var.sql_database_name != "" ? var.sql_database_name : "${var.project_name}-${var.env_name}"
+  sql_admin_login_effective    = trimspace(coalesce(var.sql_admin_login, ""))
+  sql_admin_password_effective = coalesce(var.sql_admin_password, "")
 }
 
 # -------------------------
@@ -82,7 +84,7 @@ module "app_gateway" {
 }
 
 module "sql" {
-  count                         = var.enable_sql ? 1 : 0
+  count                         = var.enable_sql && local.sql_admin_login_effective != "" && local.sql_admin_password_effective != "" ? 1 : 0
   source                        = "../../Azure/modules/sql-serverless"
   server_name                   = local.sql_server_name
   database_name                 = local.sql_database_name

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -9,6 +9,11 @@ tags = {
 }
 
 # -------------------------
+# Feature flags
+# -------------------------
+enable_sql = true
+
+# -------------------------
 # Networking
 # -------------------------
 vnet_address_space = ["10.20.0.0/16"]
@@ -89,8 +94,10 @@ sql_min_capacity         = 1
 sql_max_capacity         = 6
 sql_public_network_access = true
 
-sql_admin_login    = "sqladminstage"
-sql_admin_password = "P@ssw0rd123!Stage"
+sql_admin_login    = null
+sql_admin_password = null
+
+# SQL administrator credentials are supplied securely at deploy time (Key Vault or pipeline variables).
 
 # Firewall rules
 sql_firewall_rules = [

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -333,12 +333,14 @@ variable "sql_firewall_rules" {
 variable "sql_admin_login" {
   description = "Administrator login for the SQL server."
   type        = string
+  default     = null
 }
 
 variable "sql_admin_password" {
   description = "Administrator password for the SQL server."
   type        = string
   sensitive   = true
+  default     = null
 }
 
 # -------------------------


### PR DESCRIPTION
## Summary
- extend the Terraform plan template to source SQL admin credentials from Key Vault or pipeline variables and pass them to Terraform for every environment
- remove inline SQL admin usernames/passwords from the dev/stage/prod tfvars files, enabling SQL for non-dev environments and documenting that secrets arrive at runtime
- coalesce SQL admin values inside each environment module so the serverless database is only created when credentials are supplied

## Testing
- terraform fmt -recursive platform/infra *(fails: terraform binary unavailable and download endpoints return 403 in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0afe8e7083268351bbc926a66f20