### PR TITLE
Align arbitration runtime version with Azure .NET 6

### DIFF
--- a/platform/infra/envs/dev/main.tf
+++ b/platform/infra/envs/dev/main.tf
@@ -16,7 +16,7 @@ locals {
   arbitration_app_name                  = "web-${var.project_name}-${var.env_name}-arb"
   arbitration_plan_sku_effective        = var.arbitration_plan_sku != "" ? trimspace(var.arbitration_plan_sku) : "B1"
   arbitration_runtime_stack_effective   = var.arbitration_runtime_stack != "" ? trimspace(var.arbitration_runtime_stack) : "dotnet"
-  arbitration_runtime_version_effective = var.arbitration_runtime_version != "" ? trimspace(var.arbitration_runtime_version) : "8.0"
+  arbitration_runtime_version_effective = var.arbitration_runtime_version != "" ? trimspace(var.arbitration_runtime_version) : "v6.0"
   storage_data_name                     = lower(replace("st${var.project_name}${var.env_name}data", "-", ""))
   sql_server_name                       = "sql-${var.project_name}-${var.env_name}"
   aad_app_display                       = "aad-${var.project_name}-${var.env_name}"

--- a/platform/infra/envs/dev/terraform.tfvars
+++ b/platform/infra/envs/dev/terraform.tfvars
@@ -75,7 +75,7 @@ kv_public_network_access = true
 # -------------------------
 arbitration_plan_sku        = "B1"
 arbitration_runtime_stack   = "dotnet"
-arbitration_runtime_version = "8.0"
+arbitration_runtime_version = "v6.0"
 
 arbitration_connection_strings = [
   {

--- a/platform/infra/envs/prod/terraform.tfvars
+++ b/platform/infra/envs/prod/terraform.tfvars
@@ -70,6 +70,7 @@ app_service_connection_strings = {
 # -------------------------
 # Arbitration App
 # -------------------------
+arbitration_runtime_version = "v6.0"
 arbitration_app_settings = {
   "Storage__Connection" = "DefaultEndpointsProtocol=https;AccountName=prodarbitstorage;AccountKey=FakeKeyForProd==;EndpointSuffix=core.windows.net"
   "Storage__Container"  = "arbitration-calculator"

--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -70,6 +70,7 @@ app_service_connection_strings = {
 # -------------------------
 # Arbitration App
 # -------------------------
+arbitration_runtime_version = "v6.0"
 arbitration_app_settings = {
   "Storage__Connection" = "DefaultEndpointsProtocol=https;AccountName=stagearbitstorage;AccountKey=FakeKeyForStage==;EndpointSuffix=core.windows.net"
   "Storage__Container"  = "arbitration-calculator"


### PR DESCRIPTION
## Summary
- default the arbitration App Service runtime version in the dev configuration to the Azure .NET 6 identifier
- update each environment's terraform.tfvars to use the v6.0 runtime setting expected by Azure

## Testing
- `terraform -chdir=platform/infra/envs/dev validate` *(fails: terraform CLI is not installed in the execution environment)*
- `terraform -chdir=platform/infra/envs/stage validate` *(fails: terraform CLI is not installed in the execution environment)*
- `terraform -chdir=platform/infra/envs/prod validate` *(fails: terraform CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0af3b3708326a36fd1ef8a24ecde