### PR TITLE
Add arbitration app modules to stage environment

### DIFF
--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -63,15 +63,27 @@ app_service_app_settings = {
 app_service_connection_strings = {
   PrimaryDatabase = {
     type  = "SQLAzure"
-    value = "Server=tcp:sql-arbit-stage.database.windows.net,1433;Initial Catalog=halomd;User ID=sqladminstage;Password=P@ssw0rd123!Stage;Encrypt=True;"
+    value = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/app-service-primary-database-connection)"
   }
 }
 
 # -------------------------
 # Arbitration App
 # -------------------------
+arbitration_plan_sku        = "P1v3"
+arbitration_runtime_stack   = "dotnet"
+arbitration_runtime_version = "8.0"
+
+arbitration_connection_strings = [
+  {
+    name  = "DefaultConnection"
+    type  = "SQLAzure"
+    value = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/arbitration-default-connection)"
+  }
+]
+
 arbitration_app_settings = {
-  "Storage__Connection" = "DefaultEndpointsProtocol=https;AccountName=stagearbitstorage;AccountKey=FakeKeyForStage==;EndpointSuffix=core.windows.net"
+  "Storage__Connection" = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/arbitration-storage-connection)"
   "Storage__Container"  = "arbitration-calculator"
 }
 

--- a/platform/infra/envs/stage/variables.tf
+++ b/platform/infra/envs/stage/variables.tf
@@ -349,3 +349,31 @@ variable "arbitration_plan_sku" {
   type        = string
   default     = ""
 }
+
+variable "arbitration_runtime_stack" {
+  description = "Runtime stack used by the arbitration App Service."
+  type        = string
+  default     = ""
+}
+
+variable "arbitration_runtime_version" {
+  description = "Runtime version for the arbitration App Service."
+  type        = string
+  default     = ""
+}
+
+variable "arbitration_app_settings" {
+  description = "App settings applied to the arbitration App Service."
+  type        = map(string)
+  default     = {}
+}
+
+variable "arbitration_connection_strings" {
+  description = "Connection strings for the arbitration App Service."
+  type = list(object({
+    name  = string
+    type  = string
+    value = string
+  }))
+  default = []
+}


### PR DESCRIPTION
## Summary
- add arbitration runtime and connection variables to the stage environment configuration
- provision the stage key vault and arbitration app service modules alongside the core infrastructure
- update stage tfvars to source connection strings and storage settings from Key Vault secrets

## Testing
- terraform -chdir=platform/infra/envs/stage init -backend=false *(fails: terraform not installed in container)*
- terraform -chdir=platform/infra/envs/stage validate *(not run; depends on terraform init)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0b08490c83269d5491bfa74743d5