### PR TITLE
Normalize stage arbitration connection strings

### DIFF
--- a/platform/infra/envs/stage/terraform.tfvars
+++ b/platform/infra/envs/stage/terraform.tfvars
@@ -85,12 +85,13 @@ arbitration_app_settings = {
   "Storage__Container"  = "arbitration-calculator"
 }
 
-arbitration_connection_strings = {
-  DefaultConnection = {
+arbitration_connection_strings = [
+  {
+    name  = "DefaultConnection"
     type  = "SQLAzure"
     value = "@Microsoft.KeyVault(SecretUri=https://kv-arbit-stage.vault.azure.net/secrets/arbitration-primary-connection)"
   }
-}
+]
 
 # -------------------------
 # SQL Database


### PR DESCRIPTION
## Summary
- align the stage arbitration_connection_strings variable with other environments by using the list-of-objects schema expected by the module

## Testing
- terraform -chdir=platform/infra/envs/stage validate *(fails: terraform binary is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1ee08fcc8326893ec03fcfdab14f