### PR TITLE
Remove unused Application Gateway subnet ID variables from dev and QA

### DIFF
--- a/platform/infra/envs/dev/variables.tf
+++ b/platform/infra/envs/dev/variables.tf
@@ -142,11 +142,6 @@ variable "app_gateway_subnet_key" {
   type        = string
 }
 
-variable "app_gateway_subnet_id" {
-  description = "Explicit subnet resource ID for the Application Gateway."
-  type        = string
-}
-
 # -------------------------
 # Application Gateway
 # -------------------------

--- a/platform/infra/envs/qa/variables.tf
+++ b/platform/infra/envs/qa/variables.tf
@@ -101,11 +101,6 @@ variable "app_gateway_subnet_key" {
   type        = string
 }
 
-variable "app_gateway_subnet_id" {
-  description = "Explicit subnet resource ID for the Application Gateway."
-  type        = string
-}
-
 # -------------------------
 # Application Gateway
 # -------------------------


### PR DESCRIPTION
## Summary
- remove the unused `app_gateway_subnet_id` variable declarations from the dev and QA environment variable sets since those environments rely on the subnet key mapping

## Testing
- terraform -chdir=platform/infra/envs/dev init -backend=false *(fails: terraform binary is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1ee5efe483269da999ac72c06b4a